### PR TITLE
fix: pin swig <4.5 to unblock Python bindings build

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -21,7 +21,7 @@ source:
         - python-ext-so.patch
 
 build:
-  number: 1
+  number: 2
   dynamic_linking:
     missing_dso_allowlist:
       - if: osx
@@ -41,7 +41,10 @@ requirements:
         - ninja
     - make
     - pkg-config
-    - swig
+    # SWIG 4.5.0 dropped the Python 2 -> 3 compatibility shims that mupdf's
+    # generated bindings rely on, causing 'PyString_FromString' undeclared
+    # errors. Pin below 4.5 until upstream mupdf supports SWIG 4.5.
+    - swig <4.5
     - python-clang <22
   host:
     - brotli


### PR DESCRIPTION
## Problem

All CI builds are currently failing across **every** platform (Linux, Windows, macOS, aarch64) when compiling the SWIG-generated Python bindings:

```
platform/python/mupdfcpp_swig.i.cpp:11855:66: error: 'PyString_FromString' was not declared in this scope; did you mean 'PyLong_FromString'?
```

`PyString_FromString` is a Python 2 C-API symbol that does not exist in Python 3.

## Root cause

The recipe declares `swig` with no version pin, so each build solves to the newest SWIG. **SWIG 4.5.0 was released 2026-08-06** and drops the Python 2 → 3 compatibility shims that mupdf's generated bindings rely on.

Timeline:

| Event | Date | SWIG | Result |
|-------|------|------|--------|
| Last rebuild (#97) merged | 2026-07-24 | 4.4.1 | ✅ green |
| SWIG 4.5.0 released | 2026-08-06 | — | — |
| Builds since | 2026-08-11+ | 4.5.0 | ❌ fail |

This affects `main` / any current build, not just the aarch64 migration PR (#100) where it first surfaced.

## Fix

Pin `swig <4.5` (restores 4.4.x, proven working in #97) and bump the build number.

A follow-up should track upstream mupdf compatibility with SWIG 4.5 so the pin can be lifted.

> Note: intentionally not re-rendered — this is a build-dependency pin only (swig is not a pinned variant), so no CI config changes. Re-rendering on `main` now would also pull in the active aarch64 migration and conflict with #100.